### PR TITLE
Merge stable develop with font

### DIFF
--- a/.spacemacs
+++ b/.spacemacs
@@ -11,21 +11,24 @@ values."
    dotspacemacs-configuration-layer-path '("~/Dev/spacemacs/")
    dotspacemacs-configuration-layers
    '(
-     (theming :variables
-              theming-headings-inherit-from-default 'all
-              theming-headings-same-size 'all
-              theming-headings-bold 'all)
      (auto-completion :variables auto-completion-enable-sort-by-usage t)
-     semantic
      emacs-lisp
+     extra-langs
+     git
+     (ibuffer :variables ibuffer-group-buffers-by nil)
      markdown
+     ranger
+     semantic
      (shell :variables
             shell-default-height 30
             shell-default-position 'bottom
             shell-default-shell 'zsh)
-     (ibuffer :variables ibuffer-group-buffers-by nil)
      (spell-checking :variables syntax-checking-enable-by-default nil)
-     extra-langs
+     (theming :variables
+              theming-headings-inherit-from-default 'all
+              theming-headings-same-size 'all
+              theming-headings-bold 'all)
+
      ;; Custom
      my-mac
      my-ibuffer
@@ -113,8 +116,14 @@ It is called immediately after `dotspacemacs/init'.  You are free to put almost
 any user code here.  The exception is org related code, which should be placed
 in `dotspacemacs/user-config'."
   (setq-default
+
+   ;; Miscellaneous
    frame-title-format '(buffer-file-name "%b" "%b")
    require-final-newline t
+   vc-follow-symlinks t
+
+   ;; Ranger
+   ranger-override-dired t
 
    ;; Smartparens
    sp-highlight-pair-overlay nil
@@ -125,7 +134,7 @@ in `dotspacemacs/user-config'."
    matlab-auto-fill nil
    matlab-fill-code nil
    matlab-functions-have-end t
-   matlab-indent-function-body t
+   matlab-indent-function-body nil
 
    ;; Shell
    shell-default-term-shell "/bin/zsh"

--- a/.spacemacs
+++ b/.spacemacs
@@ -29,6 +29,7 @@ values."
      ;; Custom
      my-mac
      my-ibuffer
+     my-font
      )
    dotspacemacs-additional-packages '()
    dotspacemacs-excluded-packages

--- a/.spacemacs
+++ b/.spacemacs
@@ -15,8 +15,10 @@ values."
      emacs-lisp
      extra-langs
      git
+     github
      (ibuffer :variables ibuffer-group-buffers-by nil)
      markdown
+     latex
      ranger
      semantic
      (shell :variables
@@ -32,7 +34,7 @@ values."
      ;; Custom
      my-mac
      my-ibuffer
-     my-font
+     ;; my-font It is now configured by default font
      )
    dotspacemacs-additional-packages '()
    dotspacemacs-excluded-packages
@@ -69,11 +71,11 @@ values."
                          monokai
                          zenburn)
    dotspacemacs-colorize-cursor-according-to-state t
-   dotspacemacs-default-font '("Source Code Pro"
-                               :size 13
+   dotspacemacs-default-font '("Consolas"
+                               :size 12
                                :weight normal
                                :width normal
-                               :powerline-scale 1.1)
+                               :powerline-scale 1.2)
    dotspacemacs-leader-key "SPC"
    dotspacemacs-emacs-leader-key "<kp-enter>"
    dotspacemacs-major-mode-leader-key ","

--- a/.spacemacs
+++ b/.spacemacs
@@ -132,6 +132,7 @@ in `dotspacemacs/user-config'."
 
 (defun dotspacemacs/user-config ()
   (remove-hook 'prog-mode-hook 'spacemacs//show-trailing-whitespace)
+  (spaceline-toggle-hud-off)
   )
 
 ;; Do not write anything past this comment. This is where Emacs will

--- a/README.md
+++ b/README.md
@@ -5,4 +5,8 @@ I used to keep it in a private repo on Bitbucket, but GitHub goodies tempted me 
 
 Keep in mind that this is a game-repo. If anyone notices it, besides bringing endless shame on me, you are encouraged to suggest, correct or forget.
 
+---
+
+I also found it quite useful to keep a list of improvements and bug fixes I want to make here, under Issues tab. It saves my time when I can delay a distraction of tweaking Emacs for later. Wishlist should help me working on one and only one task at once and keep my plan organised. Which is nice.
+
 Thanks.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # spacemacs
-My [Spacemacs](https://github.com/syl20bnr/spacemacs) configuration. 
+My Emacs configuration on top of [Spacemacs](https://github.com/syl20bnr/spacemacs). 
 
 I used to keep it in a private repo on Bitbucket, but GitHub goodies tempted me to import it here. Probably, should have named this repo better, but I will leave it for later and open an issue for that.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ My [Spacemacs](https://github.com/syl20bnr/spacemacs) configuration.
 
 I used to keep it in a private repo on Bitbucket, but GitHub goodies tempted me to import it here. Probably, should have named this repo better, but I will leave it for later and open an issue for that.
 
-Keep in mind that this is a game-repo. If anyone notices it, besides endless shame on me, you are encouraged to suggest, correct or forget.
+Keep in mind that this is a game-repo. If anyone notices it, besides bringing endless shame on me, you are encouraged to suggest, correct or forget.
 
 Thanks.

--- a/my-font/config.el
+++ b/my-font/config.el
@@ -1,0 +1,15 @@
+;; Source: http://stackoverflow.com/a/13879078/3885799
+;; Initial step to font specification
+
+(create-fontset-from-fontset-spec
+ "-*-consolas-*-*-*-*-12-*-*-*-*-*-fontset-consolas,
+    ascii:-*-consolas-*-*-*-*-12-*-*-*-*-*-iso8859-1,
+    latin-iso8859-1:-*-consolas-*-*-*-*-12-*-*-*-*-*-iso8859-1,
+    latin-iso8859-15:-*-consolas-*-*-*-*-12-*-*-*-*-*-iso8859-15")
+
+(setq default-frame-alist '((width . 100) 
+                            (height . 44) 
+                            (top . 50) ;pixels
+                            (left . 50) ;pixels
+                            (font . "fontset-consolas")
+                            ))

--- a/my-mac/packages.el
+++ b/my-mac/packages.el
@@ -37,6 +37,7 @@
     :config (mac-key-mode t)))
 
 (defun my-mac/post-init-mac-key-mode ()
+  (spacemacs/set-leader-keys-for-minor-mode 'mac-key-mode "iq" 'quoted-insert)
   (when (configuration-layer/package-usedp 'redo+)
     (define-key mac-key-mode-map [(control shift z)] 'redo))
   (when (configuration-layer/package-usedp 'comment-dwim-2)


### PR DESCRIPTION
Minor config changes that do not crash or disable Emacs work. `my-font` is no longer active, but should be in the development soon.
